### PR TITLE
Windows support

### DIFF
--- a/mixer/Makefile
+++ b/mixer/Makefile
@@ -8,8 +8,8 @@ TARG=sdl/mixer
 
 GOFILES:=constants.go
 CGOFILES:=mixer.go
-CGO_CFLAGS:=-I/usr/local/include
-CGO_LDFLAGS:=-lSDL_mixer -L/usr/local/lib
+CGO_CFLAGS:=-I/usr/local/include -Ic:/msys/1.0/local/include
+CGO_LDFLAGS:=-lSDL_mixer -L/usr/local/lib -Lc:/msys/1.0/local/lib
 
 CLEANFILES+=mixer
 

--- a/sdl/Makefile
+++ b/sdl/Makefile
@@ -7,9 +7,9 @@ GOFILES:=constants.go structs.$(O).go
 
 CGOFILES:=sdl.go
 
-CGO_LDFLAGS:=`pkg-config --libs sdl` -lSDL_image
+CGO_LDFLAGS:=-Lc:/msys/1.0/local/lib -lSDL -lSDL_image
 
-CGO_CFLAGS:=`pkg-config --cflags sdl`
+CGO_CFLAGS:=-Ic:/msys/1.0/local/include
 
 CLEANFILES+=sdl
 

--- a/ttf/Makefile
+++ b/ttf/Makefile
@@ -8,8 +8,8 @@ TARG=sdl/ttf
 
 GOFILES:=constants.go
 CGOFILES:=ttf.go
-CGO_CFLAGS:=-I /usr/local/include
-CGO_LDFLAGS:=-lSDL_ttf -L /usr/local/lib
+CGO_CFLAGS:=-I /usr/local/include -Ic:/msys/1.0/local/include
+CGO_LDFLAGS:=-lSDL_ttf -L /usr/local/lib -Lc:/msys/1.0/local/lib
 
 CLEANFILES+=ttf
 


### PR DESCRIPTION
Hi,
here's the patch that enables Go-SDL to build and install under windows/mingw32 compiler.
sdl, ttf and gfx are compiling, and I didn't succeed compiling sdl_mixer itself.
