### PR TITLE
Fix ttf/Makefile so it works on Mac OS X

### DIFF
--- a/ttf/Makefile
+++ b/ttf/Makefile
@@ -9,7 +9,7 @@ TARG=sdl/ttf
 GOFILES:=constants.go
 CGOFILES:=ttf.go
 CGO_CFLAGS:=-I /usr/local/include
-CGO_LDFLAGS:=-lSDL_ttf -L /usr/local/lib
+CGO_LDFLAGS:=-lSDL_ttf -L/usr/local/lib
 
 CLEANFILES+=ttf
 


### PR DESCRIPTION
On my Mac OS X 10.6 system the ttf module does not get compiled because there is a space between -L and the path specification in the Makefile for LDFLAGS. Removing the space fixed the problem for me.
