### PR TITLE
RWops basics and RW versions of existing applicable functions.

### DIFF
--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -524,15 +524,15 @@ func modeFromFlags(flag int) *C.char {
 	switch flag {
 	case os.O_RDONLY:
 		return C.CString("r")
-	case os.O_WRONLY | os.O_CREAT:
+	case os.O_WRONLY | os.O_CREATE:
 		return C.CString("w")
-	case os.O_WRONLY | os.O_APPEND | os.O_CREAT:
+	case os.O_WRONLY | os.O_APPEND | os.O_CREATE:
 		return C.CString("a")
 	case os.O_RDWR:
 		return C.CString("r+")
-	case os.O_RDWR | os.O_CREAT:
+	case os.O_RDWR | os.O_CREATE:
 		return C.CString("w+")
-	case os.O_RDWR | os.O_APPEND | os.O_CREAT:
+	case os.O_RDWR | os.O_APPEND | os.O_CREATE:
 		return C.CString("a+")
 	default:
 		SetError("Unkown mode.")


### PR DESCRIPTION
This implements the RWops type and the functions for loading an RWops from various locations. It also adds a function to load an RWops from an io.Reader. The RWops type has several methods that are designed to make it compatible with io.Reader, io.Writer, io.Seeker, and io.Closer.

It also implements the RW versions of IMG_Load and TTF_LoadFont.

I know there's already a pull request that has the RWops functions in it, but I was halfway through writing this when I noticed it, so I decided to finish it anyways. Sorry.
