### PR TITLE
An RWops changes and fixed os API breakage.

### DIFF
--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -524,15 +524,15 @@ func modeFromFlags(flag int) *C.char {
 	switch flag {
 	case os.O_RDONLY:
 		return C.CString("r")
-	case os.O_WRONLY | os.O_CREAT:
+	case os.O_WRONLY | os.O_CREATE:
 		return C.CString("w")
-	case os.O_WRONLY | os.O_APPEND | os.O_CREAT:
+	case os.O_WRONLY | os.O_APPEND | os.O_CREATE:
 		return C.CString("a")
 	case os.O_RDWR:
 		return C.CString("r+")
-	case os.O_RDWR | os.O_CREAT:
+	case os.O_RDWR | os.O_CREATE:
 		return C.CString("w+")
-	case os.O_RDWR | os.O_APPEND | os.O_CREAT:
+	case os.O_RDWR | os.O_APPEND | os.O_CREATE:
 		return C.CString("a+")
 	default:
 		SetError("Unkown mode.")


### PR DESCRIPTION
Just some small changes:
- Changed FreeRW() to RWops.Free(). Seemed more consistent.
- Changed all instances of os.O_CREAT to os.O_CREATE.

That's it.
