### PR TITLE
Fix comparison between 'int' and 'uintptr' in func ListModes.

### DIFF
--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -94,10 +94,10 @@ func ListModes(format *PixelFormat, flags uint32) []Rect {
 		return nil
 	}
 
-	var count int
+	var count uint
 	ptr := *modes //first element in the list
 	for count = 0; ptr != nil; count++ {
-		ptr = *(**C.SDL_Rect)(unsafe.Pointer(uintptr(unsafe.Pointer(modes)) + uintptr(count*unsafe.Sizeof(ptr))))
+		ptr = *(**C.SDL_Rect)(unsafe.Pointer(uintptr(unsafe.Pointer(modes)) + uintptr(count*uint(unsafe.Sizeof(ptr)))))
 	}
 	var ret = make([]Rect, count-1)
 


### PR DESCRIPTION
Needs an explicit conversion, count can be uint, too.
