### PR TITLE
Makefile fixes for FreeBSD

### DIFF
--- a/mixer/Makefile
+++ b/mixer/Makefile
@@ -9,6 +9,11 @@ TARG=sdl/mixer
 GOFILES:=constants.go
 CGOFILES:=mixer.go
 
+ifeq ($(GOOS),freebsd)
+CGO_CFLAGS:=-I/usr/local/include
+CGO_LDFLAGS:=-lSDL_mixer -L/usr/local/lib
+endif
+
 CLEANFILES+=mixer
 
 include $(GOROOT)/src/Make.pkg

--- a/ttf/Makefile
+++ b/ttf/Makefile
@@ -9,6 +9,11 @@ TARG=sdl/ttf
 GOFILES:=constants.go
 CGOFILES:=ttf.go
 
+ifeq ($(GOOS),freebsd)
+CGO_CFLAGS:=-I/usr/local/include
+CGO_LDFLAGS:=-lSDL_ttf -L/usr/local/lib
+endif
+
 CLEANFILES+=ttf
 
 GC=${O}g -I../sdl/_obj


### PR DESCRIPTION
These changes make Go-SDL compile on FreeBSD, without breaking other $(GOOS).
