### PR TITLE
Re: #35: "Package SDL_ttf was not found in the pkg-config search path."

### DIFF
--- a/mixer/Makefile
+++ b/mixer/Makefile
@@ -9,6 +9,9 @@ TARG=sdl/mixer
 GOFILES:=constants.go
 CGOFILES:=mixer.go chunks.go
 
+CGO_CFLAGS:=`sdl-config --cflags`
+CGO_LDFLAGS:=`sdl-config --libs`
+
 ifeq ($(GOOS),freebsd)
 CGO_CFLAGS:=-I/usr/local/include
 CGO_LDFLAGS:=-lSDL_mixer -L/usr/local/lib

--- a/mixer/chunks.go
+++ b/mixer/chunks.go
@@ -7,7 +7,6 @@ functions have been changed to be in a more object-oriented style
 */
 package mixer
 
-// #cgo pkg-config: SDL_mixer
 // #include "SDL_mixer.h"
 import "C"
 import "unsafe"

--- a/ttf/Makefile
+++ b/ttf/Makefile
@@ -9,6 +9,9 @@ TARG=sdl/ttf
 GOFILES:=constants.go
 CGOFILES:=ttf.go
 
+CGO_CFLAGS:=`sdl-config --cflags`
+CGO_LDFLAGS:=`sdl-config --libs`
+
 ifeq ($(GOOS),freebsd)
 CGO_CFLAGS:=-I/usr/local/include
 CGO_LDFLAGS:=-lSDL_ttf -L/usr/local/lib

--- a/ttf/ttf.go
+++ b/ttf/ttf.go
@@ -7,7 +7,6 @@ that work with loaded fonts are changed to have a more object-oriented feel.
 */
 package ttf
 
-// #cgo pkg-config: SDL_ttf
 // #cgo LDFLAGS: -lSDL_ttf
 // #include "SDL_ttf.h"
 import "C"


### PR DESCRIPTION
pkg-config was unable to find files with names SDL_*.pc on some systems. In these cases the package name "sdl" is correct.

The fix I found was to instead use the command line utility/script `sdl-config` instead of pkg-config. The c/ld flags are set in the appropriate makefiles.
