### PR TITLE
Fix a nasty glitch caused by a combination of CreateRGBSurfaceFrom() and the GC.

### DIFF
--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -387,7 +387,11 @@ func CreateSurfaceFromImage(img image.Image) *Surface {
 		pix = nrgba.Pix
 	}
 
-	s := CreateRGBSurfaceFrom(&pix[0], r.Dx(), r.Dy(), 32, r.Dx()*4, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000)
+	s := CreateRGBSurface(SWSURFACE, r.Dx(), r.Dy(), 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000)
+
+	s.Lock()
+	defer s.Unlock()
+	C.memcpy(unsafe.Pointer(s.Pixels), unsafe.Pointer(&pix[0]), C.size_t(len(pix)))
 
 	return s
 }


### PR DESCRIPTION
CreateRGBSurfaceFrom() uses the existing pixel data. Using it in CreateSurfaceFromImage() doesn't work, because the Image can be freed by the garbage collector; once it's been converted to a *Surface, there's no reason to keep the Image. This method is slower, but avoids the problem.

If you know of a way to tell the garbage collector not to free the Image until the *Surface is freed, than that would be the best way to do it.
