### PR TITLE
Fixed use of Rectangle as argument to Image.NewNRGBA

### DIFF
--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -382,7 +382,7 @@ func CreateSurfaceFromImage(img image.Image) *Surface {
 	case *image.RGBA:
 		pix = c.Pix
 	default:
-		nrgba := image.NewNRGBA(r)
+		nrgba := image.NewNRGBA(r.Dx(), r.Dy())
 		draw.Draw(nrgba, r, img, image.ZP, draw.Over)
 		pix = nrgba.Pix
 	}


### PR DESCRIPTION
When compiling sdl.go I get the error:

```
6g  -o _go_.6 constants.go structs.6.go _obj/sdl.cgo1.go _obj/_cgo_gotypes.go
sdl.go:304[_obj/sdl.cgo1.go:307]: cannot use r (type image.Rectangle) as type int in function argument
sdl.go:304[_obj/sdl.cgo1.go:307]: not enough arguments in call to image.NewNRGBA
make[1]: *** [_go_.6] Error 1
make[1]: Leaving directory `/home/charlieb/tmp/Go-SDL/sdl'
make: *** [all] Error 2
```

I changed sdl.go:385 to expand the Rectangle argument to pass its height and width directly and no more errors!
